### PR TITLE
Fix E116: Invalid arguments for function

### DIFF
--- a/autoload/lsp_neosnippet.vim
+++ b/autoload/lsp_neosnippet.vim
@@ -12,5 +12,5 @@ function! s:escape_snippet(text) abort
 endfunction
 
 function! lsp_neosnippet#expand_snippet(params) abort
-    call feedkeys("\<C-r>=neosnippet#anonymous(\"" . s:escape_snippet(a:params.snippet) . "\")\<CR>")
+    call feedkeys("\<C-r>=neosnippet#anonymous('" . s:escape_snippet(a:params.snippet) . "')\<CR>")
 endfunction


### PR DESCRIPTION
Hi, I've got `Invalid arguments`.

```
E116: Invalid arguments for function neosnippet#anonymous(""
name": "${1}"${0}")
E15: Invalid expression: neosnippet#anonymous(""name": "${1}
"${0}")
```

Before
![Kapture 2020-01-19 at 1 03 39](https://user-images.githubusercontent.com/56591/72666674-01cd8280-3a58-11ea-8a83-ace632bb7012.gif)

After
![Kapture 2020-01-19 at 1 05 11](https://user-images.githubusercontent.com/56591/72666681-0abe5400-3a58-11ea-998f-11d3874a7659.gif)

Thank you.