### PR TITLE
add the 'n' flag to feedkeys()

### DIFF
--- a/autoload/lsp_neosnippet.vim
+++ b/autoload/lsp_neosnippet.vim
@@ -15,5 +15,5 @@ function! s:escape_snippet(text) abort
 endfunction
 
 function! lsp_neosnippet#expand_snippet(params) abort
-    call feedkeys("\<C-r>=neosnippet#anonymous('" . s:escape_snippet(a:params.snippet) . "')\<CR>")
+    call feedkeys("\<C-r>=neosnippet#anonymous('" . s:escape_snippet(a:params.snippet) . "')\<CR>", 'n')
 endfunction


### PR DESCRIPTION
Hello. I've got `E488`.

`feedkeys()` remaps keys by default, so errors may occur.

Thank you.